### PR TITLE
Console output improvements

### DIFF
--- a/plugin/src/main/groovy/com/gradleup/staticanalysis/DefaultViolationsEvaluator.groovy
+++ b/plugin/src/main/groovy/com/gradleup/staticanalysis/DefaultViolationsEvaluator.groovy
@@ -29,14 +29,14 @@ class DefaultViolationsEvaluator implements ViolationsEvaluator {
         int errorsDiff = Math.max(0, totalErrors - penalty.maxErrors)
         int warningsDiff = Math.max(0, totalWarnings - penalty.maxWarnings)
         if (errorsDiff > 0 || warningsDiff > 0) {
-            throw new GradleException("Violations limit exceeded by $errorsDiff errors, $warningsDiff warnings.\n\n$fullMessage")
+            throw new GradleException("Violations limit exceeded by $errorsDiff errors, $warningsDiff warnings.\n$fullMessage")
         } else if (!fullMessage.isEmpty()) {
-            logger.warn "\nViolations found ($totalErrors errors, $totalWarnings warnings)\n\n$fullMessage"
+            logger.warn "\nViolations found ($totalErrors errors, $totalWarnings warnings)\n$fullMessage"
         }
     }
 
     private static String getViolationsMessage(Violations violations, ReportUrlRenderer reportUrlRenderer) {
         "$violations.name violations found ($violations.errors errors, $violations.warnings warnings). See the reports at:\n" +
-                "${violations.reports.collect { "- ${reportUrlRenderer.render(it)}" }.join('\n')}"
+                "${violations.reports.collect { "${reportUrlRenderer.render(it)}" }.join('\n')}"
     }
 }

--- a/plugin/src/test/groovy/com/gradleup/staticanalysis/DefaultViolationsEvaluatorTest.groovy
+++ b/plugin/src/test/groovy/com/gradleup/staticanalysis/DefaultViolationsEvaluatorTest.groovy
@@ -47,9 +47,8 @@ class DefaultViolationsEvaluatorTest {
 
         def expected = """    
             Violations found (1 errors, 0 warnings)
-            
             > $TOOL_NAME violations found (1 errors, 0 warnings). See the reports at:
-            - $consoleClickableFileUrl
+            $consoleClickableFileUrl
             """
         assertThat(warningLog).isEqualTo(expected.stripIndent())
     }
@@ -73,9 +72,8 @@ class DefaultViolationsEvaluatorTest {
         } catch (GradleException e) {
             def expected =
                     """|Violations limit exceeded by 0 errors, 1 warnings.
-                       |
                        |> $TOOL_NAME violations found (1 errors, 2 warnings). See the reports at:
-                       |- $consoleClickableFileUrl
+                       |$consoleClickableFileUrl
                        |"""
             assertThat(e.message).isEqualTo(expected.stripMargin())
         }


### PR DESCRIPTION
Before we had 2 minor issues with output:
- IntelliJ would cut the error message from summary because of excessive space
- The dash `-` in the beginning makes it hard to copy paste file paths